### PR TITLE
make exclusion check case insensitive 

### DIFF
--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -77,7 +77,7 @@ func globFiles(extension string) ([]string, error) {
 out:
 	for _, match := range matches {
 		for _, exclusion := range exclusionList {
-			if match == exclusion {
+			if strings.EqualFold(match, exclusion) {
 				continue out
 			}
 		}


### PR DESCRIPTION
default gitlab wiki pages are generated as lowercase

```
_sidebar.md
home.md
```